### PR TITLE
Add GDAL and tippecanoe install commands to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,25 @@ Make tiles out of trees.
 
 ## Getting Started
 
-To intall the nodejs dependencies:
+To install the node.js dependencies:
 
 ```bash
 npm install
 ```
 
-We also depend on [GDAL](https://gdal.org) and [Tippecanoe](https://github.com/mapbox/tippecanoe). On Macs, both can be installed through brew.
+We also depend on [GDAL](https://gdal.org) and [Tippecanoe](https://github.com/mapbox/tippecanoe). On Macs, both can be installed through [Homebrew](https://brew.sh).
+
+To install GDAL using Homebrew:
+
+```bash
+brew install gdal
+```
+
+To install tippecanoe using Homebrew:
+
+```bash
+brew install tippecanoe
+```
 
 ## Running
 


### PR DESCRIPTION
This was my first time trying to run the scripts in this repo and I ran into an error. The relevant part of the error message was

```bash
$ npm run convert
...
Error: spawn ogr2ogr ENOENT
    at ChildProcess._handle.onexit 
...
```

After closer inspection, the problem was that I overlooked that the README stated we needed to install GDAL and tippecanoe. I added the commands to install them to the README to hopefully make it more explicit.