### PR TITLE
Fix file mapping for New Haven

### DIFF
--- a/sources/usa.js
+++ b/sources/usa.js
@@ -126,9 +126,9 @@ export default [
     srs: null,
     brokenDownload: false,
     download:
-      "https://urban-resources-initiative.carto.com/tables/newhavenstreettrees_carto_mapping_05242022/public",
+      "https://urban-resources-initiative.carto.com/api/v2/sql?filename=newhavenstreettrees_carto_mapping_05242022&q=select+*+from+public.newhavenstreettrees_carto_mapping_05242022&format=csv&bounds=&api_key=&skipfields=the_geom_webmercator,the_geom",
     format: "csv",
-    filename: "newhavenstreettrees_carto_mapping_05242022.csv",
+    filename: "new-haven.csv",
     gdal_options: null,
     license: null,
     email: "colleen.murphy-dunning@yale.edu",


### PR DESCRIPTION
Summary:
- Fixes URL for downloading the CSV file 
- Fixes the name of the output file 

Tests:
- I removed any new-haven files locally. 
- Next, ran `npm run download` which downloaded the csv file to data/raw 
- Then, ran `npm run convert` which created a geojson file in data/geojson
- Finally, ran `npm run normalize` which outputted a geojson file in data/normalized 

## Example object from data/normalized: 
```bash
(base) camillele @ Camilles-MBP ~/Desktop/waterthetrees/wtt_area/data/normalized
└─ $ ▶ gj new-haven.geojsons 
{
  "type": "Feature",
  "properties": {
    "scientific": "__UNKNOWN",
    "genus": " ",
    "species": " ",
    "common": "*Unknown",
    "dbh": "2",
    "planted": "1/11/2017",
    "address": "308 Alden Av",
    "ref": "71",
    "id": 4487995385067315,
    "sourceId": "new-haven",
    "city": "New Haven",
    "country": "United States",
    "email": "colleen.murphy-dunning@yale.edu",
    "download": "https://urban-resources-initiative.carto.com/api/v2/sql?filename=newhavenstreettrees_carto_mapping_05242022&q=select+*+from+public.newhavenstreettrees_carto_mapping_05242022&format=csv&bounds=&api_key=&skipfields=the_geom_webmercator,the_geom",
    "info": "https://urban-resources-initiative.carto.com/me",
    "lat": 41.3245735200001,
    "lng": -72.96377563,
    "count": 1
  },
  "geometry": {
    "type": "Point",
    "coordinates": [
      -72.96377563,
      41.3245735200001
    ]
  },
  "id": 4487995385067315
}
```