### PR TITLE
Add data source for Hong Kong

### DIFF
--- a/sources/china.js
+++ b/sources/china.js
@@ -1,0 +1,33 @@
+export default [
+  {
+    country: "China",
+    city: "Hong Kong",
+    short: "Hong Kong",
+    long: "Hong Kong",
+    id: "hong_kong",
+    id_city_name: "hong_kong",
+    primary: "hong_kong",
+    center: null,
+    latitude: null,
+    longitude: null,
+    info: "https://hub.arcgis.com/datasets/esrihk::old-and-valuable-trees-and-stonewall-trees-in-hong-kong/about",
+    srs: null,
+    brokenDownload: false,
+    download:
+      "https://opendata.arcgis.com/api/v3/datasets/1eb1ece1b6264d5abf85feb067e33508_0/downloads/data?format=geojson&spatialRefId=4326&where=1%3D1",
+    format: "geojson",
+    filename: "Old_and_Valuable_Trees_and_Stonewall_Trees_in_Hong_Kong.geojson",
+    gdal_options: null,
+    license: null,
+    email: null,
+    contact: null,
+    crosswalk: {
+      species: "Species",
+      notes: "Mitigation Measure",
+      health: "Condition",
+      location: "Location",
+      updated: "Last Inspection Date",
+    },
+  },
+];
+

--- a/sources/hong-kong-sar.js
+++ b/sources/hong-kong-sar.js
@@ -1,6 +1,6 @@
 export default [
   {
-    country: "China",
+    country: "Hong Kong Special Administrative Region of the People's Republic of China",
     city: "Hong Kong",
     short: "Hong Kong",
     long: "Hong Kong",


### PR DESCRIPTION
Summary: 
- Adds new data source for Hong Kong from ArcGIS 
- Includes only columns where data is in English 

Testing: 
- Ran `npm run download` which downloads the geojson file to data/raw 
- Ran `npm run convert` which saves file to data/geojson
- Ran `npm run normalize` which saves the file to data/normalized 

Confirmed the file(s) populate in each of the directories above. 